### PR TITLE
Fix bug empty line chat log

### DIFF
--- a/line_utils.py
+++ b/line_utils.py
@@ -23,15 +23,19 @@ def read_line_chat(file_name):
     is_found_first_date = False
     for chat in chats:
         date = re.findall(r'\d+\.\d+\.\d+', chat)
-        
+
         #Android date format
         if len(date) == 0:
             date = re.findall('^\d+\/\d+\/\d+', chat)
-        
+
         #Skip line until found date
         if is_found_first_date == False and len(date) == 0:
             continue
-            
+
+        #Empty line
+        if len(chat.strip()) == 0:
+            continue
+
         if len(date) >= 1:
             is_found_first_date = True
             d = date[0]

--- a/line_utils.py
+++ b/line_utils.py
@@ -26,7 +26,7 @@ def read_line_chat(file_name):
         
         #Android date format
         if len(date) == 0:
-            date = re.findall('\d+\/\d+\/\d+', chat)
+            date = re.findall('^\d+\/\d+\/\d+', chat)
         
         #Skip line until found date
         if is_found_first_date == False and len(date) == 0:

--- a/line_utils.py
+++ b/line_utils.py
@@ -72,7 +72,6 @@ def split_chat(chat, users):
 
 def bin_time(t, n_bin=8):
     """bin time in the day to number of bins"""
-    t = t.replace('24:', '00:')
     bin_size = int(24./n_bin)
     h = parser.parse(t).hour
     for i in range(n_bin + 1):

--- a/line_utils.py
+++ b/line_utils.py
@@ -36,6 +36,7 @@ def read_line_chat(file_name):
             is_found_first_date = True
             d = date[0]
         else:
+            chat = re.sub('^24:', '00:', chat)
             chats_dict['chats'].append([d, chat])
     chats_dict['total_chats'] = len(chats_dict['chats'])
     return chats_dict
@@ -268,9 +269,7 @@ def plot_response_rate(chats_dict):
     users_response = []
     for responses in responses_all:
         time_previous, user_previous = responses[0]
-        time_previous = time_previous.replace('24:', '00:')
         for i in range(1, len(responses)):
-            responses[i][0] = responses[i][0].replace('24:', '00:')
             if user_previous == responses[i][1]:
                 time_previous, user_previous = responses[i]
             else:

--- a/line_utils.py
+++ b/line_utils.py
@@ -20,9 +20,20 @@ def read_line_chat(file_name):
     chats = list(lines)
     chats = [c[0] for c in chats if len(c) > 0]
     chats_dict = defaultdict(list)
+    is_found_first_date = False
     for chat in chats:
         date = re.findall(r'\d+\.\d+\.\d+', chat)
+        
+        #Android date format
+        if len(date) == 0:
+            date = re.findall('\d+\/\d+\/\d+', chat)
+        
+        #Skip line until found date
+        if is_found_first_date == False and len(date) == 0:
+            continue
+            
         if len(date) >= 1:
+            is_found_first_date = True
             d = date[0]
         else:
             chats_dict['chats'].append([d, chat])
@@ -60,6 +71,7 @@ def split_chat(chat, users):
 
 def bin_time(t, n_bin=8):
     """bin time in the day to number of bins"""
+    t = t.replace('24:', '00:')
     bin_size = int(24./n_bin)
     h = parser.parse(t).hour
     for i in range(n_bin + 1):
@@ -256,7 +268,9 @@ def plot_response_rate(chats_dict):
     users_response = []
     for responses in responses_all:
         time_previous, user_previous = responses[0]
+        time_previous = time_previous.replace('24:', '00:')
         for i in range(1, len(responses)):
+            responses[i][0] = responses[i][0].replace('24:', '00:')
             if user_previous == responses[i][1]:
                 time_previous, user_previous = responses[i]
             else:


### PR DESCRIPTION
Multiple line message some line has the only whitespace will get error when called get_users() 

**Error message**:
![screenshot at 2017-10-01 21-40-05](https://user-images.githubusercontent.com/144775/31055776-3d8fa0f6-a6f2-11e7-9cbb-5e3b9949b364.png)

**Message multiple lines with an only whitespace**:
![screenshot at 2017-10-01 21-44-26](https://user-images.githubusercontent.com/144775/31055783-5175f84a-a6f2-11e7-984f-2fb9db599ff3.png)

